### PR TITLE
Seperate C & C++ & rename C-SHARP to C# for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <br>
 </p>
 
-If you are interested in Open Source and are considering to join the community of Open Source developers, 
-it is possible that in this list you will find the project that will suit you. 
+If you are interested in Open Source and are considering to join the community of Open Source developers,
+it is possible that in this list you will find the project that will suit you.
 
 **We don't add to list mammoth's shit. Only active and interesting projects.**
 
@@ -16,8 +16,9 @@ Wanna support us? Just share this list with your friends on [Twitter](https://tw
 
 ## Languages
 
- - [C/C++](languages/C_C%2B%2B.md)
- - [C#](languages/C-SHARP.md)
+ - [C](languages/C.md)
+ - [C#](languages/C%23.md)
+ - [C++](languages/C%2B%2B.md)
  - [Clojure](languages/CLOJURE.md)
  - [Common Lisp](languages/COMMON_LISP.md)
  - [CSS](languages/CSS.md)

--- a/languages/C#.md
+++ b/languages/C#.md
@@ -1,3 +1,5 @@
+## C&#35;
+
 [**Nancy**](https://github.com/NancyFx/Nancy) is a lightweight, low-ceremony, framework for building HTTP based services on .NET Framework/Core and [Mono](http://mono-project.com). The goal of the framework is to stay out of the way as much as possible and provide a super-duper-happy-path to all interactions.
 
 Nancy is designed to handle `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT` and `PATCH` requests and provides a simple, elegant, [Domain Specific Language (DSL)](http://en.wikipedia.org/wiki/Domain-specific_language) for returning a response with just a couple of keystrokes, leaving you with more time to focus on the important bits..

--- a/languages/C++.md
+++ b/languages/C++.md
@@ -1,26 +1,8 @@
-## C and C++
+## C++
 
 [**Qt**](https://www.qt.io/) is an LGPL application framework supported on most platforms - including embedded -, and covers most of C++ application development needs : GUI widgets, event loop, networking, serialization, reflection, javascript engines, web browser integration... As well as a declarative reactive user-interface programming language based on Javascript, QML that can even be used for 3D content creation.
 
 ![qt](http://doc.qt.io/qt-5/images/used-in-examples/gallery/images/qt-logo@2x.png)
----
-
-[**NumPy**](https://github.com/numpy/numpy) is the fundamental package needed for scientific computing with Python.
-This package contains:
-
-   * a powerful N-dimensional array object
-   * sophisticated (broadcasting) functions
-   * tools for integrating C/C++ and Fortran code
-   * useful linear algebra, Fourier transform, and random number capabilities.
-
-It derives from the old Numeric code base and can be used as a replacement for Numeric. It also adds the features introduced by numarray and can be used to replace numarray.
-
-![numpy](http://www.numpy.org/_static/numpy_logo.png)
-
----
-[**Torch**](https://github.com/torch/torch7) is a scientific computing framework with wide support for machine learning algorithms that puts GPUs first. It is easy to use and efficient, thanks to an easy and fast scripting language, LuaJIT, and an underlying C/CUDA implementation.
-
-![torch](https://cdn-images-1.medium.com/max/720/0*6tYC_KkQvSAAL6h3.png)
 
 ---
 [**Electron**](https://github.com/electron/electron) lets you write cross-platform desktop applications
@@ -34,11 +16,6 @@ editor](https://github.com/atom/atom) and many other [apps](http://electron.atom
 [**Caffe**](https://github.com/BVLC/caffe) is a deep learning framework made with expression, speed, and modularity in mind. It is developed by the Berkeley Vision and Learning Center (BVLC) and community contributors.
 
 ![caffe](https://cdn-images-1.medium.com/max/720/0*PuFfFqw5QvvXMdC7.png)
-
----
-[**libuv**](https://github.com/libuv/libuv) is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by Node.js, but it's also used by Luvit, Julia, pyuv, and others.
-
-![libduv](https://cdn-images-1.medium.com/max/720/0*_Gj_yjlEAdE7x8Hi.png)
 
 ---
 [**µWS**](https://github.com/uWebSockets/uWebSockets) is one of the most lightweight, efficient & scalable WebSocket server implementations available. It features an easy-to-use, fully async object-oriented interface and scales to millions of connections using only a fraction of memory compared to the competition. While performance and scalability are two of our top priorities, we consider security, stability and standards compliance paramount. License is zlib/libpng (very permissive & suits commercial applications).
@@ -61,56 +38,10 @@ editor](https://github.com/atom/atom) and many other [apps](http://electron.atom
 ![robomongo](https://robomongo.org/static/screens-transparent-6e2a44fd.png)
 
 ---
-[**Lwan**](https://github.com/lpereira/lwan/) is a high-performance & scalable web server for glibc/Linux
-platforms.
-
-In development for almost 4 years, Lwan was until now a personal research
-effort that focused mostly on building a **solid infrastructure** for
-a lightweight and speedy web server:
-
-  - Low memory footprint (~500KiB for 10k idle connections)
-  - Minimal memory allocations & copies
-  - Minimal system calls
-  - Hand-crafted HTTP request parser
-  - Files are served using the most efficient way according to their size
-    - No copies between kernel and userland for files larger than 16KiB
-    - Smaller files are sent using vectored I/O of memory-mapped buffers
-    - Header overhead is considered before compressing small files
-  - Mostly wait-free multi-threaded design
-  - Diminute code base with roughly 7200 lines of C code
-
-It is now transitioning into a fully working, capable HTTP server. It is
-not, however, as feature-packed as other popular web servers. But it is
-[free software](http://www.gnu.org/philosophy/free-sw.html), so scratching
-your own itches and making Lwan hum the way you want it to is possible.
-
----
-[**netdata**](https://github.com/firehol/netdata) is a system for distributed real-time performance and health monitoring. It provides unparalleled insights, in real-time, of everything happening on the system it runs (including applications such as web and database servers), using modern interactive web dashboards.
-
-netdata is fast and efficient, designed to permanently run on all systems (physical & virtual servers, containers, IoT devices), without disrupting their core function.
-
-![g1](https://cloud.githubusercontent.com/assets/2662304/14092712/93b039ea-f551-11e5-822c-beadbf2b2a2e.gif)
-
-
----
-[**Skynet**](https://github.com/cloudwu/skynet) is a lightweight online game framework, and it can be used in many other fields.
-
----
-[**Nuklear**](https://github.com/vurtun/nuklear) - is a minimal state immediate mode graphical user interface toolkit written in ANSI C and licensed under public domain. It was designed as a simple embeddable user interface for application and does not have any dependencies, a default renderbackend or OS window and input handling but instead provides a very modular library approach by using simple input state for input and draw commands describing primitive shapes as output. So instead of providing a layered library that tries to abstract over a number of platform and render backends it only focuses on the actual UI.
-
-![nuklear](https://cloud.githubusercontent.com/assets/8057201/13538240/acd96876-e249-11e5-9547-5ac0b19667a0.png)
-![nuklear](https://cloud.githubusercontent.com/assets/8057201/13538243/b04acd4c-e249-11e5-8fd2-ad7744a5b446.png)
-
----
 [**MXNet**](https://github.com/dmlc/mxnet) is a deep learning framework designed for both efficiency and flexibility. It allows you to mix the flavours of symbolic programming and imperative programming to maximize efficiency and productivity. In its core, a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly. A graph optimization layer on top of that makes symbolic execution fast and memory efficient. The library is portable and lightweight, and it scales to multiple GPUs and multiple machines.
 
 ![mxnet](https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo-m/mxnet2.png)
 
-
----
-[**Kore**](https://github.com/jorisvink/kore) is an easy to use web application framework for writing scalable web APIs in C. Its main goals are security, scalability and allowing rapid development and deployment of such APIs.
-
-![kore](https://kore.io/images/logos/logo-front.png)
 
 ---
 [**openFrameworks**](https://github.com/openframeworks/openFrameworks) is an open source C++ toolkit for creative coding. It includes tools for 2D/3D graphics, audio, and video components along with many addons for integrations with everything from XBOX Kinects to OpenCV.

--- a/languages/C.md
+++ b/languages/C.md
@@ -1,0 +1,71 @@
+## C
+
+[**NumPy**](https://github.com/numpy/numpy) is the fundamental package needed for scientific computing with Python.
+This package contains:
+
+   * a powerful N-dimensional array object
+   * sophisticated (broadcasting) functions
+   * tools for integrating C/C++ and Fortran code
+   * useful linear algebra, Fourier transform, and random number capabilities.
+
+It derives from the old Numeric code base and can be used as a replacement for Numeric. It also adds the features introduced by numarray and can be used to replace numarray.
+
+![numpy](http://www.numpy.org/_static/numpy_logo.png)
+
+---
+[**Torch**](https://github.com/torch/torch7) is a scientific computing framework with wide support for machine learning algorithms that puts GPUs first. It is easy to use and efficient, thanks to an easy and fast scripting language, LuaJIT, and an underlying C/CUDA implementation.
+
+![torch](https://cdn-images-1.medium.com/max/720/0*6tYC_KkQvSAAL6h3.png)
+
+---
+[**libuv**](https://github.com/libuv/libuv) is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by Node.js, but it's also used by Luvit, Julia, pyuv, and others.
+
+![libduv](https://cdn-images-1.medium.com/max/720/0*_Gj_yjlEAdE7x8Hi.png)
+
+---
+[**Lwan**](https://github.com/lpereira/lwan/) is a high-performance & scalable web server for glibc/Linux
+platforms.
+
+In development for almost 4 years, Lwan was until now a personal research
+effort that focused mostly on building a **solid infrastructure** for
+a lightweight and speedy web server:
+
+  - Low memory footprint (~500KiB for 10k idle connections)
+  - Minimal memory allocations & copies
+  - Minimal system calls
+  - Hand-crafted HTTP request parser
+  - Files are served using the most efficient way according to their size
+    - No copies between kernel and userland for files larger than 16KiB
+    - Smaller files are sent using vectored I/O of memory-mapped buffers
+    - Header overhead is considered before compressing small files
+  - Mostly wait-free multi-threaded design
+  - Diminute code base with roughly 7200 lines of C code
+
+It is now transitioning into a fully working, capable HTTP server. It is
+not, however, as feature-packed as other popular web servers. But it is
+[free software](http://www.gnu.org/philosophy/free-sw.html), so scratching
+your own itches and making Lwan hum the way you want it to is possible.
+
+---
+[**netdata**](https://github.com/firehol/netdata) is a system for distributed real-time performance and health monitoring. It provides unparalleled insights, in real-time, of everything happening on the system it runs (including applications such as web and database servers), using modern interactive web dashboards.
+
+netdata is fast and efficient, designed to permanently run on all systems (physical & virtual servers, containers, IoT devices), without disrupting their core function.
+
+![g1](https://cloud.githubusercontent.com/assets/2662304/14092712/93b039ea-f551-11e5-822c-beadbf2b2a2e.gif)
+
+
+---
+[**Skynet**](https://github.com/cloudwu/skynet) is a lightweight online game framework, and it can be used in many other fields.
+
+---
+[**Nuklear**](https://github.com/vurtun/nuklear) - is a minimal state immediate mode graphical user interface toolkit written in ANSI C and licensed under public domain. It was designed as a simple embeddable user interface for application and does not have any dependencies, a default renderbackend or OS window and input handling but instead provides a very modular library approach by using simple input state for input and draw commands describing primitive shapes as output. So instead of providing a layered library that tries to abstract over a number of platform and render backends it only focuses on the actual UI.
+
+![nuklear](https://cloud.githubusercontent.com/assets/8057201/13538240/acd96876-e249-11e5-9547-5ac0b19667a0.png)
+![nuklear](https://cloud.githubusercontent.com/assets/8057201/13538243/b04acd4c-e249-11e5-8fd2-ad7744a5b446.png)
+
+---
+[**Kore**](https://github.com/jorisvink/kore) is an easy to use web application framework for writing scalable web APIs in C. Its main goals are security, scalability and allowing rapid development and deployment of such APIs.
+
+![kore](https://kore.io/images/logos/logo-front.png)
+
+---


### PR DESCRIPTION
I looked through the C_C++.md file, went through the github repos of each project, and added each C & C++ project into their own file. This is in response to issue #42.

I also noticed the C-SHARP file didn't use the # symbol or have a heading in the file. I went ahead and added those so the files would be sorted alphabetically in the directory and C-SHARP wasn't the first file above C.

I made sure to update the README to include the new links.