### PR TITLE
Add LuaCheck to Lua.md

### DIFF
--- a/languages/LUA.md
+++ b/languages/LUA.md
@@ -86,3 +86,40 @@ app:run()
 
 ---
 [**KOReader**](https://github.com/koreader/koreader) is a document viewer application, originally created for Kindle e-ink readers. It currently runs on Kindle, Kobo, PocketBook, Ubuntu Touch and Android (2.3+) devices. Developers can also run KOReader emulator for development purpose on desktop PC with Linux and Windows and Mac OSX (experimental for now).
+
+---
+[**LuaCheck**](https://github.com/mpeterv/luacheck) A tool for linting and static analysis of Lua code.
+
+Usage:
+```lua
+luacheck src extra_file.lua another_file.lua
+```
+
+Output:
+```lua
+Checking src/good_code.lua               OK
+Checking src/bad_code.lua                3 warnings
+
+    src/bad_code.lua:3:23: unused variable length argument
+    src/bad_code.lua:7:10: setting non-standard global variable embrace
+    src/bad_code.lua:8:10: variable opt was previously defined as an argument on line 7
+
+Checking src/python_code.lua             1 error
+
+    src/python_code.lua:1:6: expected '=' near '__future__'
+
+Checking extra_file.lua                  5 warnings
+
+    extra_file.lua:3:18: unused argument baz
+    extra_file.lua:4:8: unused loop variable i
+    extra_file.lua:13:7: accessing uninitialized variable a
+    extra_file.lua:14:1: value assigned to variable x is unused
+    extra_file.lua:21:7: variable z is never accessed
+
+Checking another_file.lua                2 warnings
+
+    another_file.lua:2:7: unused variable height
+    another_file.lua:3:7: accessing undefined variable heigth
+
+Total: 10 warnings / 1 error in 5 files
+```


### PR DESCRIPTION
Luacheck is a static analyzer and a linter for Lua. Luacheck detects various issues such as usage of undefined global variables, unused variables and values, accessing uninitialized variables, unreachable code and more. Most aspects of checking are configurable: there are options for defining custom project-related globals, for selecting set of standard globals (version of Lua standard library), for filtering warnings by type and name of related variable, etc. The options can be used on the command line, put into a config or directly into checked files as Lua comments.

Luacheck supports checking Lua files using syntax of Lua 5.1, Lua 5.2, Lua 5.3 and LuaJIT. Luacheck itself is written in Lua and runs on all of mentioned Lua versions.