### PR TITLE
alphabetic order added in haskell and emacs-lisp #101

### DIFF
--- a/languages/EMACS_LISP.md
+++ b/languages/EMACS_LISP.md
@@ -1,8 +1,16 @@
-## Emacs Lisp
+## Alphabetical index of projects in Emacs-Lisp :
 
-[**Magit**](https://github.com/magit/magit) is an interface to the version control system Git, implemented as an Emacs package. Magit aspires to be a complete Git porcelain. While we cannot claim that Magit wraps and improves upon each and every Git command, it is complete enough to allow even experienced Git users to perform almost all of their daily version control tasks directly from within Emacs. While many fine Git clients exist, only Magit and Git itself deserve to be called porcelains.
+|       |       |       |       |       |       |       |
+|---    |---    |---    |---    |---    |---    |    ---|
+|[A](#a)|[B](#b)|[C](#c)|[D](#d)|[E](#e)|[F](#f)|[G](#g)|
+|[H](#h)|[I](#i)|[J](#j)|[K](#k)|[L](#l)|[M](#m)|[N](#n)|
+|[P](#p)|[Q](#q)|[R](#r)|[S](#s)|[T](#t)|[U](#u)|[V](#v)|
+|[W](#w)|[X](#x)|[Y](#y)|[Z](#z)|       |       |       |
+|       |       |       |       |       |       |       |
 
-![magit](https://cdn-images-1.medium.com/max/720/0*kPc9uZd0tipuHwz8.)
+<br>
+
+## A
 
 ---
 
@@ -23,6 +31,17 @@
 ![alchemist](https://raw.githubusercontent.com/tonini/alchemist.el/master/images/alchemist_logo.png)
 
 ---
+
+## M
+
+[**Magit**](https://github.com/magit/magit) is an interface to the version control system Git, implemented as an Emacs package. Magit aspires to be a complete Git porcelain. While we cannot claim that Magit wraps and improves upon each and every Git command, it is complete enough to allow even experienced Git users to perform almost all of their daily version control tasks directly from within Emacs. While many fine Git clients exist, only Magit and Git itself deserve to be called porcelains.
+
+![magit](https://cdn-images-1.medium.com/max/720/0*kPc9uZd0tipuHwz8.)
+
+---
+
+## U
+
 The [**use-package**](https://github.com/jwiegley/use-package) macro allows you to isolate package configuration in your .emacs file in a way that is both performance-oriented and, well, tidy. I created it because I have over 80 packages that I use in Emacs, and things were getting difficult to manage. Yet with this utility my total load time is around 2 seconds, with no loss of functionality!
 
 Here is the simplest use-package declaration:

--- a/languages/HASKELL.md
+++ b/languages/HASKELL.md
@@ -1,28 +1,17 @@
-## Haskell
+## Alphabetical index of projects in Haskell :
 
-[**Stack**](https://github.com/commercialhaskell/stack) is a cross-platform program for developing Haskell projects. It is intended for Haskellers both new and experienced.
+|       |       |       |       |       |       |       |
+|---    |---    |---    |---    |---    |---    |    ---|
+|[A](#a)|[B](#b)|[C](#c)|[D](#d)|[E](#e)|[F](#f)|[G](#g)|
+|[H](#h)|[I](#i)|[J](#j)|[K](#k)|[L](#l)|[M](#m)|[N](#n)|
+|[P](#p)|[Q](#q)|[R](#r)|[S](#s)|[T](#t)|[U](#u)|[V](#v)|
+|[W](#w)|[X](#x)|[Y](#y)|[Z](#z)|       |       |       |
+|       |       |       |       |       |       |       |
 
----
-[**Pandoc**](https://github.com/jgm/pandoc) is a Haskell library for converting from one markup format to another, and a command-line tool that uses this library. It can read Markdown, CommonMark, PHP Markdown Extra, GitHub-Flavored Markdown, MultiMarkdown, and (subsets of) Textile, reStructuredText, HTML, LaTeX, MediaWiki markup, TWiki markup, Haddock markup, OPML, Emacs Org mode, DocBook, txt2tags, EPUB, ODT and Word docx; and it can write plain text, Markdown, CommonMark, PHP Markdown Extra,GitHub-Flavored Markdown, MultiMarkdown, reStructuredText, XHTML, HTML5, LaTeX (including beamer slide shows), ConTeXt, RTF, OPML, DocBook, OpenDocument, ODT, Word docx, GNU Texinfo, MediaWiki markup, DokuWiki markup, ZimWiki markup, Haddock markup, EPUB (v2 or v3), FictionBook2, Textile, groff man pages, Emacs Org mode, AsciiDoc, InDesign ICML, TEI Simple, and Slidy, Slideous, DZSlides, reveal.js or S5 HTML slide shows. It can also produce PDF output on systems where LaTeX, ConTeXt, or wkhtmltopdf is installed.
+<br>
 
-![pandoc](https://cdn-images-1.medium.com/max/720/0*LyYHxYObKJg0DCi9.png)
+## G
 
----
-[**Yesod**](https://github.com/yesodweb/yesod)  —  an advanced RESTful web framework using the Haskell programming language.
-
-![yesod](https://cdn-images-1.medium.com/max/720/0*gG0fpIadl2ev6sTt.png)
-
----
-[**hadolint**](https://github.com/lukasmartinelli/hadolint)  —  a smarter Dockerfile linter that helps you build best practice Docker images. The linter is parsing the Dockerfile into an AST and performs rules on top of the AST. hadolint written in Haskell.
-
-![hadolint](https://github.com/lukasmartinelli/hadolint/raw/master/screenshot.png)
-
----
-[**postgrest**](https://github.com/begriffs/postgrest)  —  PostgREST serves a fully RESTful API from any existing PostgreSQL database. It provides a cleaner, more standards-compliant, faster API than you are likely to write from scratch. PostgREST written in Haskell.
-
-![postgrest](https://github.com/begriffs/postgrest/raw/master/static/logo.png)
-
----
 [**givegif**](https://github.com/passy/givegif) - GIFs on the command line.
 
 ![gg](https://github.com/passy/givegif/raw/master/media/usage.gif)
@@ -31,4 +20,44 @@
 [**Glance**](https://github.com/rgleichman/glance) is a visual syntax for the programming language Haskell. The goal of this project is to increase programmer happiness and productivity by allowing programmers to create and understand programs in new and different ways. Currently, the Glance executable produces a visual representation of your code in the form of an SVG image when given a textual Haskell source file. In the future, I hope to create a visual editor for Haskell. Please scroll down to see some example images.
 
 ---
+
+## H
+
+[**hadolint**](https://github.com/lukasmartinelli/hadolint)  —  a smarter Dockerfile linter that helps you build best practice Docker images. The linter is parsing the Dockerfile into an AST and performs rules on top of the AST. hadolint written in Haskell.
+
+![hadolint](https://github.com/lukasmartinelli/hadolint/raw/master/screenshot.png)
+
+---
 [**http-client**](https://github.com/snoyberg/http-client) is a mega-repo for housing the http-client family of packages for Haskell. These packages provide a low level HTTP client engine (http-client), different backends for providing SSL support (http-client-tls and http-client-openssl), and higher-level APIs for user convenience (http-conduit).
+
+--- 
+
+## P
+
+
+[**Pandoc**](https://github.com/jgm/pandoc) is a Haskell library for converting from one markup format to another, and a command-line tool that uses this library. It can read Markdown, CommonMark, PHP Markdown Extra, GitHub-Flavored Markdown, MultiMarkdown, and (subsets of) Textile, reStructuredText, HTML, LaTeX, MediaWiki markup, TWiki markup, Haddock markup, OPML, Emacs Org mode, DocBook, txt2tags, EPUB, ODT and Word docx; and it can write plain text, Markdown, CommonMark, PHP Markdown Extra,GitHub-Flavored Markdown, MultiMarkdown, reStructuredText, XHTML, HTML5, LaTeX (including beamer slide shows), ConTeXt, RTF, OPML, DocBook, OpenDocument, ODT, Word docx, GNU Texinfo, MediaWiki markup, DokuWiki markup, ZimWiki markup, Haddock markup, EPUB (v2 or v3), FictionBook2, Textile, groff man pages, Emacs Org mode, AsciiDoc, InDesign ICML, TEI Simple, and Slidy, Slideous, DZSlides, reveal.js or S5 HTML slide shows. It can also produce PDF output on systems where LaTeX, ConTeXt, or wkhtmltopdf is installed.
+
+![pandoc](https://cdn-images-1.medium.com/max/720/0*LyYHxYObKJg0DCi9.png)
+
+---
+
+[**postgrest**](https://github.com/begriffs/postgrest)  —  PostgREST serves a fully RESTful API from any existing PostgreSQL database. It provides a cleaner, more standards-compliant, faster API than you are likely to write from scratch. PostgREST written in Haskell.
+
+![postgrest](https://github.com/begriffs/postgrest/raw/master/static/logo.png)
+
+
+---
+
+## S
+
+[**Stack**](https://github.com/commercialhaskell/stack) is a cross-platform program for developing Haskell projects. It is intended for Haskellers both new and experienced.
+
+---
+
+## Y
+
+[**Yesod**](https://github.com/yesodweb/yesod)  —  an advanced RESTful web framework using the Haskell programming language.
+
+![yesod](https://cdn-images-1.medium.com/max/720/0*gG0fpIadl2ev6sTt.png)
+
+


### PR DESCRIPTION
alphabetic order added in haskell and emacs-lisp following python markdown file's style