### PR TITLE
Fixed image URL(s) for some items in JavaScript. Old images threw a 404.

### DIFF
--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -90,7 +90,7 @@ This is a cloud-enabled, mobile-ready, offline-storage, AngularJS powered HTML5 
 ---
 [**Docsify**](https://github.com/QingWei-Li/docsify)  —  :black_joker: A magical documentation site generator.
 
-![docsify](https://raw.githubusercontent.com/QingWei-Li/docsify/master/media/docsify.png)
+![docsify](https://docsify.js.org/_media/icon.svg)
 
 ## E
 

--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -62,7 +62,7 @@ Chart.js provides two different builds that are available for your use. The Char
 ---
 [**Countly**](https://github.com/countly/countly-server)  —  A plugin-based, real-time mobile, web and desktop analytics platform with more than 10 different SDKs. Countly also includes an extensive push notifications and crash reporting service for mobile devices.
 
-![countly](https://camo.githubusercontent.com/f60fc1f56ac415bde000defba9c26a8469404866/687474703a2f2f636f756e742e6c792f77702d636f6e74656e742f75706c6f6164732f323031362f31322f636f756e746c795f64617368626f6172645f636f6d6d756e6974795f31365f31322e706e67)
+![countly](https://count.ly/images/home/countly-overview.png?v2)
 
 ---
 [**Code Surfer**](https://github.com/pomber/code-surfer)  —  React component for scrolling, zooming and highlighting code samples <🏄/>


### PR DESCRIPTION
I have added a new image url for **Countly**, **Docsify.** Under **JavaScript**. Idk how this works @lk-geimfari, I pulled a request for the first image of Countly, but then I added another commit for Docsify. Will I need another PR?
