### PR TITLE
Added Catalyst framework

### DIFF
--- a/languages/PYTHON.md
+++ b/languages/PYTHON.md
@@ -76,6 +76,31 @@ It runs on Windows, Linux and MacOs and has been in active development for over 
 It also includes a build in server that allows reading your ebooks from anywhere.
 
 ---
+[**Catalyst**](https://github.com/catalyst-team/catalyst) – high-level utils for PyTorch DL & RL research.
+It was developed with a focus on reproducibility, fast experimentation and code/ideas reusing. Being able to research/develop something new, rather than write another regular train loop.
+
+Catalyst helps you write compact
+but full-featured DL & RL pipelines in a few lines of code.
+You get a training loop with metrics, early-stopping, model checkpointing
+and other features without the boilerplate.
+
+Features:
+- Universal train/inference loop.
+- Configuration files for model/data hyperparameters.
+- Reproducibility – all source code and environment variables will be saved.
+- Callbacks – reusable train/inference pipeline parts.
+- Training stages support.
+- Easy customization.
+- PyTorch best practices (SWA, OneCycle with warmup, Ranger optimizer, FP16 and more).
+
+
+<p align="center">
+    <a href="https://github.com/catalyst-team/catalyst">
+        <img src="https://raw.githubusercontent.com/catalyst-team/catalyst-pics/master/pics/catalyst_logo.png">
+    </a>
+</p>
+
+---
 [**cerberus**](https://github.com/nicolaiarocci/cerberus)  —  a lightweight and extensible data validation library for Python.
 
 Supported: *Python 2/3*


### PR DESCRIPTION
Hi! I'm a developer of the [Catalyst framework](https://github.com/catalyst-team/catalyst) for Deep Leaning on PyTorch. I would like to add a link to your list. We actively support the project and release a new release every month.

The data scientists community likes Catalyst. It is actively used for competitions on Kaggle. PyTorch has also added us to [its ecosystem](https://pytorch.org/ecosystem/).