### PR TITLE
Add Themis to Golang

### DIFF
--- a/languages/GOLANG.md
+++ b/languages/GOLANG.md
@@ -381,6 +381,13 @@ Purpose of this tool is to provide a visual overview of your program by using th
 
 [**fasthttp**](https://github.com/valyala/fasthttp) — is a fast HTTP implementation for Go.
 
+
+## Themis
+
+[**Themis**](https://github.com/cossacklabs/themis) - a multi-platform framework for solving typical data security tasks: secure data storage, secure messaging, zero-knowledge proof authentication, etc. Themis has unified easy-to-use hard-to-misuse API for 14 languages and platforms, so it's a best fit for multi-platform apps and apps with end-to-end encryption. It hides cryptographic details, so developers don't need to know the difference between AES CBC mode and AES GCM mode to encrypt the data.
+
+![Themis encryption framework](https://raw.githubusercontent.com/wiki/cossacklabs/themis/images/logo.png)
+
 ## Tyk
 
 [**Tyk**](https://github.com/TykTechnologies/tyk) — is an open source, fast and scalable API management platform featuring an API gateway, API analytics, developer portal and API management dashboard.


### PR DESCRIPTION
[Themis](https://github.com/cossacklabs/themis) is a popular open source cryptographic library available for 14 languages. Go is one of supported languages, Themis has [docs and examples on Go](https://docs.cossacklabs.com/themis/languages/go/).


---

I think that "Go" section is a bit out-of-order, so I've added Themis as close to "T" letter as possible.