### PR TITLE
Add Themis to Java

### DIFF
--- a/languages/JAVA.md
+++ b/languages/JAVA.md
@@ -57,6 +57,12 @@ is an open source testing framework for Java released under the MIT License. The
 
 [**SpringFox**](https://github.com/springfox/springfox) Automated JSON API documentation for API's built with Spring
 
+## T
+
+[**Themis**](https://github.com/cossacklabs/themis) - a multi-platform framework for solving typical data security tasks: secure data storage, secure messaging, zero-knowledge proof authentication, etc. Themis has unified easy-to-use hard-to-misuse API for 14 languages and platforms, so it's a best fit for multi-platform apps and apps with end-to-end encryption. It hides cryptographic details, so developers don't need to know the difference between AES CBC mode and AES GCM mode to encrypt the data. Recommended by OWASP MASVS.
+
+![Themis encryption framework](https://raw.githubusercontent.com/wiki/cossacklabs/themis/images/logo.png)
+
 ## V
 
 [**Virgil PureKit**](https://github.com/VirgilSecurity/virgil-purekit-java) is an open-source security framework for user passwords and data protection in a database with functionality against online and offline attacks. PureKit can be used within any database or login system that uses a password, so it’s applicable for a company of any industry or size. It's available for several different programming languages, including Java.


### PR DESCRIPTION
[Themis](https://github.com/cossacklabs/themis) is a popular open source cryptographic library available for 14 languages. Java is one of supported languages, Themis is available for [Java desktop apps](https://docs.cossacklabs.com/themis/languages/java/installation-desktop/) and [Java mobile apps](https://docs.cossacklabs.com/themis/languages/java/installation-android/).