### PR TITLE
Add Gifcurry for Haskell

### DIFF
--- a/languages/HASKELL.md
+++ b/languages/HASKELL.md
@@ -12,6 +12,11 @@
 
 ## G
 
+[**Gifcurry**](https://github.com/lettier/gifcurry) is the open-source, Haskell-built video editor for GIF makers. Load a video, make some edits, and save it as a GIF—Gifcurry makes your life easy! Most video formats should work, so go wild. And since it's made with Haskell, you know it's good.
+
+![gifcurry](https://i.imgur.com/SJ8zovM.gif)
+
+---
 [**givegif**](https://github.com/passy/givegif) - GIFs on the command line.
 
 ![gg](https://github.com/passy/givegif/raw/master/media/usage.gif)


### PR DESCRIPTION
Hello, I want to add gifcurry to the list.

Gifcurry is amazing tool for making gif. Besides gui, gifcurry is also available in cli. Here is reason, from  its repo, why gifcurry is awesome:

![image](https://user-images.githubusercontent.com/26477782/95229084-57d29800-082a-11eb-9edf-54ada7762eb7.png)