### PR TITLE
Update BuckleScript name

### DIFF
--- a/languages/OCAML.md
+++ b/languages/OCAML.md
@@ -10,10 +10,6 @@
 
 <br>
 
-## B
-
-[**BuckleScript**](https://github.com/bloomberg/bucklescript) is a JavaScript backend for OCaml focused on smooth integration and clean generated code.
-
 ## C
 
 [**Coq**](https://github.com/coq/coq) is a formal proof management system. It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs.
@@ -31,6 +27,9 @@
 ## R
 
 [**Reason**](https://github.com/facebook/reason) is a alternate syntax for OCaml. It's simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems. 
+
+
+[**ReScript**](https://github.com/rescript-lang/rescript-compiler) is a JavaScript backend for OCaml focused on smooth integration and clean generated code.
 
 ## T
 [**Tezos**](https://github.com/tezos/tezos/) is a distributed consensus platform with meta-consensus capability. Tezos not only comes to consensus about state, like BTC or ETH. It also comes to consensus about how the protocol and the nodes should adapt and upgrade.


### PR DESCRIPTION
Updating BuckleScript (OCaml) name because it's changed to ReScript.
[BuckleScript is rebranding](https://rescript-lang.org/blog/bucklescript-is-rebranding)