### PR TITLE
Added Ogre3D (C++ open-source rendering engine)

### DIFF
--- a/languages/C++.md
+++ b/languages/C++.md
@@ -83,6 +83,11 @@ I2P (Invisible Internet Protocol) is a universal anonymous network layer. All co
 
 ## O
 
+[**Ogre3D**](https://www.ogre3d.org/) is one of the most popular open-source graphics rendering engines, and has been used in a large number of production projects, in such diverse areas as games, simulators, educational software, interactive art, scientific visualisation, and others.
+
+![ogre3d](https://i1.wp.com/www.ogre3d.org/wp-content/uploads/2019/08/gallery512-2.png)
+
+
 [**OpenCV**](http://opencv.org) (Open Source Computer Vision Library) is an open source computer vision and machine learning software library. OpenCV was built to provide a common infrastructure for computer vision applications and to accelerate the use of machine perception in the commercial products. Being a BSD-licensed product, OpenCV makes it easy for businesses to utilize and modify the code.
 
 ![opencv](https://opencv.org/wp-content/uploads/2019/02/opencv-logo-1.png)


### PR DESCRIPTION
Since 2001, OGRE has grown to become one of the most popular open-source rendering engines. I used it in multiple occasions and it's quite nice :)
> I added the link to the main website but there is a whole [org ](https://github.com/OGRECave) in github with many repos (including the engine itself). I you want I could switch the link to this [one](https://github.com/OGRECave/ogre).