### PR TITLE
Add MudBlazor to C#

### DIFF
--- a/languages/C#.md
+++ b/languages/C#.md
@@ -185,6 +185,9 @@ The [**corefx**](https://github.com/dotnet/corefx) repo contains the library imp
 [**Mono**](https://github.com/mono/mono) is a software platform designed to allow developers to easily create cross platform applications. It is an open source implementation of Microsoft's .NET Framework based on the ECMA standards for C# and the Common Language Runtime.
 
 ---
+[**MudBlazor**](https://github.com/Garderoben/MudBlazor) is an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. ([Demo](https://mudblazor.com))
+
+---
 [**MusicStore**](https://github.com/aspnet/MusicStore) is a sample ASP.NET Core application.
 
 ---


### PR DESCRIPTION
Added https://mudblazor.com an ambitious Material Design component framework for Blazor with an emphasis on ease of use and clear structure. It is perfect for .NET developers who want to rapidly build web applications without having to struggle with CSS and Javascript. MudBlazor, being written entirely in C#, empowers them to adapt, fix or extend the framework and the multitude of examples in the documentation makes learning MudBlazor very easy. 
	
Design goals:
 - Clean and aesthetic graphic design based on Material Design
 - Clear and easy to understand structure
 - Good documentation with many examples and source snippets
 - All components are written entirely in C#, no JavaScript allowed (except absolutely necessary)
 - All CSS is encapsulated, users largely don't need it (but they can)
 - No dependencies on other component libraries, 100% control over components and features
 - Stability! We strive for a complete test coverage. 
 - Releasing often so developers can get their PRs and fixes in a timely fashion

