### PR TITLE
docs: fix simple typo, eductional -> educational

### DIFF
--- a/languages/C#.md
+++ b/languages/C#.md
@@ -64,7 +64,7 @@ The [**corefx**](https://github.com/dotnet/corefx) repo contains the library imp
 [**CORS**](https://github.com/aspnet/CORS) is an implementations of common CORS policy and CORS middleware.
 
 ---
-[**C-Sharp**](https://github.com/TheAlgorithms/C-Sharp) This repository contains algorithms and data structures implemented in C# for eductional purposes.
+[**C-Sharp**](https://github.com/TheAlgorithms/C-Sharp) This repository contains algorithms and data structures implemented in C# for educational purposes.
 
 ---
 [**CppSharp**](https://github.com/mono/CppSharp) is a tool and set of libraries which allows programmers to use C/C++ libraries with high-level programming languages (such as C#).


### PR DESCRIPTION
There is a small typo in languages/C#.md.

Should read `educational` rather than `eductional`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md