### PR TITLE
Add graphql-schema-typescript

### DIFF
--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -129,9 +129,6 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![ghost](http://imgur.com/gLARrBe.png)
 
 ---
-[**graphql-schema-typescript**](https://github.com/dangcuuson/graphql-schema-typescript) - A GraphQL utility to generate Typescript from Schema Definition
-
----
 [**Gulp**](https://github.com/gulpjs/gulp)  — The streaming build system.
 
 ![gulp](http://imgur.com/92epDTJ.png)

--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -129,6 +129,9 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![ghost](http://imgur.com/gLARrBe.png)
 
 ---
+[**graphql-schema-typescript**](https://github.com/dangcuuson/graphql-schema-typescript) - A GraphQL utility to generate Typescript from Schema Definition
+
+---
 [**Gulp**](https://github.com/gulpjs/gulp)  — The streaming build system.
 
 ![gulp](http://imgur.com/92epDTJ.png)

--- a/languages/TYPESCRIPT.md
+++ b/languages/TYPESCRIPT.md
@@ -25,6 +25,10 @@ Angular Material brings high-quality UI components built with Angular 2 and Type
 
 [Check out the available components](https://material.angular.io/components)
 
+## G
+
+[**graphql-schema-typescript**](https://github.com/dangcuuson/graphql-schema-typescript) - A GraphQL utility to generate Typescript from Schema Definition
+
 ## I
 
 [**Ionic**](https://github.com/driftyco/ionic)  —  A complete mobile toolkit, built for web developers.


### PR DESCRIPTION
graphql-schema-typescript is a package that "translates" graphql schemas into typescript, this helps a lot when you are a client or a server because it generates the entire types for responses and resolvers.