### PR TITLE
Add XMonad to Haskell projects

### DIFF
--- a/languages/HASKELL.md
+++ b/languages/HASKELL.md
@@ -52,7 +52,7 @@
 
 ## X
 
-[**XMonad**](https://xmonad.org/) is a dynamically tiled window manager which is fully configurable in Haskell. It automates windows positioning, reducing time spent aligning new windows and searching for them.
+[**XMonad**](https://github.com/xmonad/xmonad) is a dynamically tiled window manager which is fully configurable in Haskell. It automates windows positioning, reducing time spent aligning new windows and searching for them.
 
 ![xmonad](https://wiki.haskell.org/wikiupload/thumb/b/b2/Byorgey-config.png/800px-Byorgey-config.png)
 


### PR DESCRIPTION
I think the Haskell projects list is very short compared to what exists in the world.

I'm proposing this PR to add XMonad (as it is one of the flagship projects for Haskell) and if you are ok with it I can propose a larger one with a few more suggestions.