### PR TITLE
Add graphql-ruby to ruby projects.

### DIFF
--- a/languages/RUBY.md
+++ b/languages/RUBY.md
@@ -104,7 +104,8 @@ conn.get do |req|
   req.options.open_timeout = 2      # connection open timeout in seconds
 end
 ```
-
+## G
+[**Graphql-Ruby**](https://github.com/rmosolgo/graphql-ruby) is a Ruby implementation for Graphql lovers.
 ## H
 
 [**Huginn**](https://github.com/cantino/huginn) is a system for building agents that perform automated tasks for you online. They can read the web, watch for events, and take actions on your behalf. Huginn's Agents create and consume events, propagating them along a directed graph. Think of it as a hackable Yahoo! Pipes plus IFTTT on your own server. You always know who has your data. You do.

--- a/languages/RUBY.md
+++ b/languages/RUBY.md
@@ -119,6 +119,8 @@ end
 
 [**Kaminari**](https://github.com/kaminari/kaminari) is a Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs.
 
+## M
+[**MetaTags**](https://github.com/kpumuk/meta-tags). Gem to make your Rails application SEO-friendly
 ## O
 [**Octokit**](https://github.com/octokit/octokit.rb) is a library to access the github data and improve yours automation
 


### PR DESCRIPTION
Add graphql implementation in ruby for graphql lovers. 