### PR TITLE
Update link to React documentation

### DIFF
--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -1,12 +1,12 @@
 ## Alphabetical index of projects in Javascript:
 
-|       |       |       |       |       |       |       |
-|---    |---    |---    |---    |---    |---    |    ---|
-|[A](#a)|[B](#b)|[C](#c)|[D](#d)|[E](#e)|[F](#f)|[G](#g)|
-|[H](#h)|[I](#i)|[J](#j)|[K](#k)|[L](#l)|[M](#m)|[N](#n)|
-|[O](#o)|[P](#p)|[Q](#q)|[R](#r)|[S](#s)|[T](#t)|[U](#u)|
-|[V](#v)|[W](#w)|[X](#x)|[Y](#y)|[Z](#z)|       |       |
-|       |       |       |       |       |       |       |
+|         |         |         |         |         |         |         |
+| ------- | ------- | ------- | ------- | ------- | ------- | ------- |
+| [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) |
+| [H](#h) | [I](#i) | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) |
+| [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s) | [T](#t) | [U](#u) |
+| [V](#v) | [W](#w) | [X](#x) | [Y](#y) | [Z](#z) |         |         |
+|         |         |         |         |         |         |         |
 
 <br>
 
@@ -17,6 +17,7 @@
 ![aframe](https://cloud.githubusercontent.com/assets/674727/21375108/2c10b308-c6e0-11e6-945e-2394beb9a8ed.png)
 
 ---
+
 [**Ace**](https://github.com/ajaxorg/ace)  —  Ace is a standalone code editor written in JavaScript.
 
 Ace's goal is to create a browser based editor that matches and extends the features, usability and performance of existing native editors such as TextMate, Vim or Eclipse. It can be easily embedded in any web page or JavaScript application. Ace is developed as the primary editor for Cloud9 IDE and the successor of the Mozilla Skywriter (Bespin) Project.
@@ -30,6 +31,7 @@ Ace's goal is to create a browser based editor that matches and extends the feat
 ![async](https://cdn-images-1.medium.com/max/720/0*MB_a8lRqGYBy276_.jpg)
 
 ---
+
 [**AVA**](https://github.com/avajs/ava) is Futuristic JavaScript test runner. Ava takes advantage of JavaScript asynchronism to runs your tests concurrently, which is especially beneficial for IO heavy tests. AVA has simple test syntax and enforces atomic tests.
 
 ![](http://i.imgur.com/sUreNq4.gif)
@@ -55,10 +57,10 @@ Chart.js provides two different builds that are available for your use. The Char
 ![chart.js](https://cdn-images-1.medium.com/max/720/0*bFZZQzdNeZkoy3Ov.jpg)
 
 ---
-[**Countly**](https://github.com/countly/countly-server)  —  A plugin-based, real-time mobile, web and desktop analytics platform with more than 10 different SDKs. Countly also includes an extensive push notifications and crash reporting service for mobile devices.
+
+[**Countly**](https://github.com/countly/countly-server)  — A plugin-based, real-time mobile, web and desktop analytics platform with more than 10 different SDKs. Countly also includes an extensive push notifications and crash reporting service for mobile devices.
 
 ![countly](https://count.ly/images/home/countly-overview.png?v2)
-
 
 ## D
 
@@ -67,17 +69,19 @@ Chart.js provides two different builds that are available for your use. The Char
 ![d3](https://cdn-images-1.medium.com/max/720/0*bxHj6VbZ9lApwWyo.jpg)
 
 ---
+
 [**date-fns**](https://github.com/date-fns/date-fns) — :hourglass: Modern JavaScript date utility library :hourglass:.
 
 date-fns provides the most comprehensive, yet simple and consistent toolset for manipulating JavaScript dates in a **Browser** & **Node.js**.
 
-
 ---
+
 [**Docsify**](https://github.com/QingWei-Li/docsify)  —  :black_joker: A magical documentation site generator.
 
 ![docsify](https://docsify.js.org/_media/icon.svg)
 
 ## E
+
 [**Enzyme**](https://github.com/airbnb/enzyme) is a JavaScript Testing utility for React that makes it easier to assert, manipulate, and traverse your React Components’ output.
 
 Enzyme’s API is meant to be intuitive and flexible by mimicking jQuery’s API for DOM manipulation and traversal.
@@ -85,11 +89,13 @@ Enzyme’s API is meant to be intuitive and flexible by mimicking jQuery’s API
 Enzyme is unopinionated regarding which test runner or assertion library you use, and should be compatible with all major test runners and assertion libraries out there. The documentation and examples for enzyme use mocha and chai, but you should be able to extrapolate to your framework of choice.
 
 ---
-[**Express**](https://github.com/expressjs/express)  — Fast, unopinionated, minimalist web framework for node.  
+
+[**Express**](https://github.com/expressjs/express)  — Fast, unopinionated, minimalist web framework for node.
 
 ![express](http://imgur.com/mSHVwME.png)
 
 ---
+
 [**Exifr**](https://github.com/MikeKovarik/exifr) — The fastest and most versatile JS EXIF reading library.
 
 ![exifr](https://raw.githubusercontent.com/MikeKovarik/exifr/master/logo/blue-mini.png)
@@ -101,16 +107,19 @@ Enzyme is unopinionated regarding which test runner or assertion library you use
 ![fabric](https://raw.githubusercontent.com/kangax/fabric.js/master/lib/screenshot.png)
 
 ---
+
 [**filepond**](https://github.com/pqina/filepond) — is library that can upload anything you throw at it, optimizes images for faster uploads, and offers a great, accessible, silky smooth user experience.
 
 ![filepond](https://github.com/pqina/filepond-github-assets/blob/master/logo.svg)
 
 ---
+
 [**fullPage.js**](https://github.com/alvarotrigo/fullPage.js) — a simple and easy to use plugin to create fullscreen scrolling websites (also known as single page websites or onepage sites). It allows the creation of fullscreen scrolling websites, as well as adding some landscape sliders inside the sections of the site.
 
 ![fullpage](https://camo.githubusercontent.com/0a9ce533243ea122eb9fba3f93efb5426cc8b6e1/68747470733a2f2f7261772e6769746875622e636f6d2f616c7661726f747269676f2f66756c6c506167652e6a732f6d61737465722f6578616d706c65732f696d67732f696e74726f2e706e67)
 
 ## G
+
 [**Gatsby**](https://github.com/gatsbyjs/gatsby) — ⚛️📄🚀 Blazing-fast site generator for React
 
 Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and super extensive.
@@ -118,11 +127,13 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![gatsby](https://camo.githubusercontent.com/ac31ac54c2013850b0fb8a3a4926f4718a398fb3/68747470733a2f2f7777772e6761747362796a732e6f72672f6d6f6e6f6772616d2e737667)
 
 ---
+
 [**Ghost**](https://github.com/TryGhost/Ghost)  — A simple, powerful publishing platform.
 
 ![ghost](http://imgur.com/gLARrBe.png)
 
 ---
+
 [**Gulp**](https://github.com/gulpjs/gulp)  — The streaming build system.
 
 ![gulp](http://imgur.com/92epDTJ.png)
@@ -134,6 +145,7 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![hexo](http://imgur.com/EpeRsnm.png)
 
 ---
+
 [**Hyper**](https://github.com/zeit/hyper)  —  A terminal built on web technologies.
 
 ![hyper](https://raw.githubusercontent.com/zeit/art/525bd1bb39d97dd3b91c976106a6d5cc5766b678/hyper/repo-banner.png)
@@ -141,6 +153,7 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 It is written in HTML, CSS & JavaScript.
 
 ---
+
 [**Highcharts**](https://github.com/highcharts/highcharts)  —  A charting library written in pure JavaScript, offering an easy way of adding interactive charts to your web site or web application..
 
 ![hyper](https://github.com/Pratyush2710/VassarAngularJS/blob/master/highchatrs.png?raw=true)
@@ -148,6 +161,7 @@ It is written in HTML, CSS & JavaScript.
 It is based on HTML5/SVG/VML, meaning it requires no extra plugins and it also supports a wide range of charts like spline, column, bar, maps, angular gauges among others along with being free for personal use.
 
 ---
+
 [**Hapi**](https://github.com/hapijs/hapi) is a rich framework for building applications and services. It enables developers to focus on writing reusable application logic instead of spending time building infrastructure.
 It is a configuration-driven pattern, traditionally modeled to control web server operations. A unique feature Hapi has is the ability to create a server on a specific IP, with features like the onPreHandler, we can do something with a request before it is completed by intercepting it and doing some pre-processing on the request.
 
@@ -160,11 +174,13 @@ Impress.js is inspired by the idea behind [Prezi](https://prezi.com/).
 [Check out the live demo](http://impress.github.io/impress.js).
 
 ---
+
 [**Ink**](https://github.com/vadimdemedes/ink) provides the same component-based UI building experience that React provides, but for command-line apps.
 
 ![ink](https://github.com/vadimdemedes/ink/blob/master/media/demo.svg)
 
 ---
+
 [**Insomnia**](https://github.com/Kong/insomnia) is a desktop cross-platform API client for REST and GraphQL, built on top of Electron. It takes the pain out of interacting with HTTP-based APIs. Insomnia combines an easy-to-use interface with advanced functionality like authentication helpers, code generation, and environment variables. It's an open source alternative to Postman which offers a simpler and cleaner user interface.
 
 The project's site: https://insomnia.rest/
@@ -184,11 +200,13 @@ The project's site: https://insomnia.rest/
 ![](https://camo.githubusercontent.com/de0532955fea66f17b749ef96c7efdbfad2e8bd2/687474703a2f2f692e696d6775722e636f6d2f547665617065372e706e67)
 
 ---
+
 [**Leaflet**](https://github.com/Leaflet/Leaflet) — The leading open-source JavaScript library for mobile-friendly interactive maps.
 
 ![leaflet](https://camo.githubusercontent.com/1a8472d37458cb6e12c17497d95f7752b7e63d0b60f95c507863efca493a04d3/68747470733a2f2f7261776769742e636f6d2f4c6561666c65742f4c6561666c65742f6d61737465722f7372632f696d616765732f6c6f676f2e737667)
 
 ---
+
 [**lodash**](https://github.com/lodash/lodash) — A modern JavaScript utility library delivering modularity, performance, & extras.
 
 ![lodash](http://imgur.com/dIzDcos.png)
@@ -202,16 +220,19 @@ Mailspring's UI is open source (GPLv3) and written in JavaScript with Electron a
 ![Mailspring Screenshot](https://github.com/Foundry376/Mailspring/raw/master/screenshots/hero_graphic_mac%402x.png)
 
 ---
+
 [**Marko**](https://github.com/marko-js/marko) is a friendly and super fast UI library that makes building web apps fun!
 
 ![marko](https://user-images.githubusercontent.com/3771924/29725582-a043b5fe-899a-11e7-83f8-215fdc904256.png)
 
 ---
+
 [**Moment.js**](https://github.com/moment/moment) — a lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 
 ![moment.js](https://cdn-images-1.medium.com/max/720/0*DP6jZMrfJIt2znNM.png)
 
 ---
+
 [**Meteor**](https://github.com/meteor/meteor) is an ultra-simple environment for building modern web applications.
 
 With Meteor you write apps in modern JavaScript that send data over the wire, rather than HTML using your choice of popular open-source libraries
@@ -219,6 +240,7 @@ With Meteor you write apps in modern JavaScript that send data over the wire, ra
 ![meteor](https://user-images.githubusercontent.com/841294/26841702-0902bbee-4af3-11e7-9805-0618da66a246.png)
 
 ## N
+
 [**NSFW**](https://github.com/infinitered/nsfwjs) — Client-side indecent content checking
 
 A simple JavaScript library to help you quickly identify unseemly images; all in the client's browser. NSFWJS isn't perfect, but it's pretty accurate (~90% from our test set of 15,000 test images)... and it's getting more accurate all the time.
@@ -226,11 +248,13 @@ A simple JavaScript library to help you quickly identify unseemly images; all in
 ![nsfwjs](https://github.com/infinitered/nsfwjs/raw/master/_art/nsfwjs_logo.jpg)
 
 ---
+
 [**NestJS**](https://github.com/nestjs/nest) is a framework for building efficient, scalable Node.js server-side applications. It uses modern JavaScript, is built with TypeScript (preserves compatibility with pure JavaScript) and combines elements of OOP (Object Oriented Programming), FP (Functional Programming), and FRP (Functional Reactive Programming).
 
 Under the hood, Nest makes use of Express, but also, provides compatibility with a wide range of other libraries, like e.g. Fastify, allowing for easy use of the myriad third-party plugins which are available.
 
 ---
+
 [**Next.js**](https://github.com/vercel/next.js/) is an open-source web development framework created by Vercel enabling React-based web applications with server-side rendering and generating static websites
 
 Next.js gives you the best developer experience with all the features you need for production: hybrid static & server rendering, TypeScript support, smart bundling, route pre-fetching, and more. No config needed.
@@ -238,6 +262,7 @@ Next.js gives you the best developer experience with all the features you need f
 ![next.js](https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png)
 
 ## P
+
 [**Phaser**](https://github.com/photonstorm/phaser)
 Phaser is a fast, free, and fun open source HTML5 game framework that offers WebGL and Canvas rendering across desktop and mobile web browsers. Games can be compiled to iOS, Android and native apps by using 3rd party tools. You can use JavaScript or TypeScript for development.
 
@@ -248,18 +273,18 @@ Thousands of developers from indie and multi-national digital agencies, and univ
 ![Phaser Header](https://phaser.io/images/github/300/phaser-header.png "Phaser 3 Header Banner")
 
 ---
+
 [**PM2**](http://github.com/Unitech/pm2) is a production process manager for Node.js applications with a built-in load balancer. It allows you to keep applications alive forever, to reload them without downtime and to facilitate common system admin tasks.
 
 ![Process listing](https://github.com/unitech/pm2/raw/master/pres/pm2-list.png)
 
 ---
+
 [**Popper.js**](https://popper.js.org/) This JavaScript library will help you create delightful poppers on your site. If you’re wondering what a popper is, think of it like a little thought bubble bursting from an element! Popper.js gives you some fantastic ways to arrange them, make them stick to elements, and keep them operating smoothly on any screen size
 
 ![Popper.js](https://popper.js.org/images/popper-og-image.jpg)
 
 ---
-
-
 
 [**PouchDB**](https://github.com/pouchdb/pouchdb) is an open-source JavaScript database inspired by Apache CouchDB that is designed to run well within the browser.
 
@@ -267,52 +292,53 @@ PouchDB was created to help web developers build applications that work as well 
 It enables applications to store data locally while offline, then synchronize it with CouchDB and compatible servers when the application is back online, keeping the user's data in sync no matter where they next login.
 
 Usage:
+
 ```javascript
-var db = new PouchDB('dbname');
+var db = new PouchDB("dbname");
 
 db.put({
-  _id: 'dave@gmail.com',
-  name: 'David',
-  age: 69
+  _id: "dave@gmail.com",
+  name: "David",
+  age: 69,
 });
 
-db.changes().on('change', function() {
-  console.log('Ch-Ch-Changes');
+db.changes().on("change", function () {
+  console.log("Ch-Ch-Changes");
 });
 
-db.replicate.to('http://example.com/mydb');
+db.replicate.to("http://example.com/mydb");
 ```
 
 ## R
+
 [**React**](https://github.com/facebook/react) — React is a JavaScript library for building user interfaces.
 ![React](https://www.seekpng.com/png/detail/80-803597_io-is-compatible-with-all-javascript-frameworks-and.png)
 
+- **Declarative:** React makes it painless to create interactive UIs. Design simple views for each state in your application, and React will efficiently update and render just the right components when your data changes. Declarative views make your code more predictable, simpler to understand, and easier to debug.
+- **Component-Based:** Build encapsulated components that manage their own state, then compose them to make complex UIs. Since component logic is written in JavaScript instead of templates, you can easily pass rich data through your app and keep state out of the DOM.
+- **Learn Once, Write Anywhere:** We don't make assumptions about the rest of your technology stack, so you can develop new features in React without rewriting existing code. React can also render on the server using Node and power mobile apps using [React Native](https://facebook.github.io/react-native/).
 
-* **Declarative:** React makes it painless to create interactive UIs. Design simple views for each state in your application, and React will efficiently update and render just the right components when your data changes. Declarative views make your code more predictable, simpler to understand, and easier to debug.
-* **Component-Based:** Build encapsulated components that manage their own state, then compose them to make complex UIs. Since component logic is written in JavaScript instead of templates, you can easily pass rich data through your app and keep state out of the DOM.
-* **Learn Once, Write Anywhere:** We don't make assumptions about the rest of your technology stack, so you can develop new features in React without rewriting existing code. React can also render on the server using Node and power mobile apps using [React Native](https://facebook.github.io/react-native/).
-
-[Learn how to use React in your own project](https://reactjs.org/docs/getting-started.html).
+[Learn how to use React in your own project](https://react.dev/learn).
 
 ---
+
 [**Redux**](https://github.com/facebook/react) — Redux is a predictable state container for JavaScript apps.
 
 ![React](https://redux.js.org/img/redux-logo-landscape.png)
 
+- **Predictability of outcome** There is always one source of truth, the store, with no confusion about how to sync the current state with actions and other parts of the application.
 
-* **Predictability of outcome**  There is always one source of truth, the store, with no confusion about how to sync the current state with actions and other parts of the application.
+- **Maintainability** Having a predictable outcome and strict structure makes the code easier to maintain.
 
-* **Maintainability** Having a predictable outcome and strict structure makes the code easier to maintain.
+- **Server rendering** This is very useful, especially for the initial render, making for a better user experience or search engine optimization. Just pass the store created on the server to the client side.
 
-* **Server rendering** This is very useful, especially for the initial render, making for a better user experience or search engine optimization. Just pass the store created on the server to the client side.
+- **Organization** Redux is stricter about how code should be organized, which makes code more consistent and easier for a team to work with.
 
-* **Organization** Redux is stricter about how code should be organized, which makes code more consistent and easier for a team to work with.
+- **Developer tools** Developers can track everything going on in the app in real time, from actions to state changes.
 
-* **Developer tools** Developers can track everything going on in the app in real time, from actions to state changes.
+- **Community and ecosystem** This is a huge plus whenever you’re learning or using any library or framework. Having a community behind Redux makes it even more appealing to use.
 
-* **Community and ecosystem** This is a huge plus whenever you’re learning or using any library or framework. Having a community behind Redux makes it even more appealing to use.
-
-* **Ease of testing** The first rule of writing testable code is to write small functions that do only one thing and that are independent. Redux’s code is mostly functions that are just that: small, pure and isolated.
+- **Ease of testing** The first rule of writing testable code is to write small functions that do only one thing and that are independent. Redux’s code is mostly functions that are just that: small, pure and isolated.
 
 ---
 
@@ -326,11 +352,10 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 
 [**Routing Controllers**](https://github.com/typestack/routing-controllers) — A framework for building backend applications in Node.
 
-* It is quite lightweight, easy to learn and pleasant to use.
-* It allows to create structured, declarative and beautifully organized class-based controllers.
-* It has heavy decorators usage providing with efficient logging, functionality, and test performance.
-* It can be used easily in Express / Koa using TypeScript.
-
+- It is quite lightweight, easy to learn and pleasant to use.
+- It allows to create structured, declarative and beautifully organized class-based controllers.
+- It has heavy decorators usage providing with efficient logging, functionality, and test performance.
+- It can be used easily in Express / Koa using TypeScript.
 
 ## S
 
@@ -339,22 +364,25 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ![socket.io](http://imgur.com/2p9ICjI.png)
 
 ---
+
 [**Strapi**](https://github.com/strapi/strapi) — The most advanced open-source Content Management Framework (headless-CMS) to build powerful API with no effort.
 
 ![strapi](https://camo.githubusercontent.com/4f99be4e64e0babc77b1e0dadffd3eb5ba883ebb/68747470733a2f2f626c6f672e7374726170692e696f2f636f6e74656e742f696d616765732f323031382f30382f6769746875625f707265766965772d322e706e67)
 
 ---
+
 [**strider**](https://github.com/Strider-CD/strider) — an Open Source Continuous Deployment / Continuous Integration platform. It is written in Node.JS / JavaScript and uses MongoDB as a backing store. It is published under the BSD license.
 
 ![strider](https://cdn-images-1.medium.com/max/720/0*xth8wmt1O-zAf3Hy.jpg)
 
 ---
-[**Svelte**](https://github.com/sveltejs/svelte) — Svelte is a UI framework of sorts that borrows a lot of the great ideas from some of its peers like React and Vue.js, but brings about its own interesting ideas to the table. Plus, it’s not entirely a framework in the sense that we’re used to and is perhaps better seen as a compiler.
 
+[**Svelte**](https://github.com/sveltejs/svelte) — Svelte is a UI framework of sorts that borrows a lot of the great ideas from some of its peers like React and Vue.js, but brings about its own interesting ideas to the table. Plus, it’s not entirely a framework in the sense that we’re used to and is perhaps better seen as a compiler.
 
 ![svelte](https://svelte.dev/svelte-logo-horizontal.svg)
 
 ---
+
 [**SweetAlert2**](https://github.com/limonte/sweetalert2) — An awesome replacement for JavaScript's alert.
 
 [Check out the live demo](https://github.com/limonte/sweetalert2).
@@ -362,6 +390,7 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ![sweetalert](https://raw.githubusercontent.com/sweetalert2/sweetalert2/master/assets/swal2-logo.png)
 
 ---
+
 [**Serverless Framework**](https://github.com/serverless/serverless) — Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more!
 
 The Framework uses new event-driven compute services, like AWS Lambda, Google Cloud Functions, and more. It's a command-line tool, providing scaffolding, workflow automation and best practices for developing and deploying your serverless architecture. It's also completely extensible via plugins.
@@ -375,11 +404,13 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 ![](https://raw.githubusercontent.com/DevExpress/testcafe/master/media/install-and-run-test.gif)
 
 ---
+
 [**Three.js**](https://github.com/mrdoob/three.js) is a cross-browser JavaScript library/API used to create and display animated 3D computer graphics in a web browser. Three.js uses WebGL.
 
 ![three](http://www.awwwards.com/awards/images/2014/09/threejs-img8.jpg)
 
 ---
+
 [**Tone.js**](https://github.com/Tonejs/Tone.js) is a framework for creating interactive music in the browser. It provides advanced scheduling capabilities, synths and effects, and intuitive musical abstractions built on top of the Web Audio API.
 
 [Check out the live demos.](https://tonejs.github.io/demos)
@@ -404,7 +435,7 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 
 ---
 
-[**VuePress**](https://github.com/vuejs/vuepress) — VuePress is a Minimalistic Vue-powered static site generator with Vue component based layout and is the latest project from Vue creator Evan You. On the client side, a VuePress site is an SPA powered by Vue, Vue Router and Webpack. It was originally created to support the documentation needs of Vue’s own subprojects and now it can serve your own needs. A VuePress site is in fact a SPA powered by Vue, Vue Router and webpack. If you’ve used Vue before, you will notice the familiar development experience when you are writing or developing custom themes. 
+[**VuePress**](https://github.com/vuejs/vuepress) — VuePress is a Minimalistic Vue-powered static site generator with Vue component based layout and is the latest project from Vue creator Evan You. On the client side, a VuePress site is an SPA powered by Vue, Vue Router and Webpack. It was originally created to support the documentation needs of Vue’s own subprojects and now it can serve your own needs. A VuePress site is in fact a SPA powered by Vue, Vue Router and webpack. If you’ve used Vue before, you will notice the familiar development experience when you are writing or developing custom themes.
 
 [Learn how to use VuePress - official guide](https://vuepress.vuejs.org/guide).
 
@@ -417,17 +448,18 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 ![webpack](http://imgur.com/i5lsaAm.png)
 
 ---
+
 [**web3.js - Ethereum JavaScript API**](https://github.com/ethereum/web3.js/) — web3.js is a collection of libraries which allow you to interact with a local or remote ethereum node, using a HTTP or IPC connection.
 
 ![web3.js](https://raw.githubusercontent.com/ethereum/web3.js/2.x/assets/web3js.svg?sanitize=true)
 
 ---
+
 [**WebTorrent**](https://github.com/feross/webtorrent) — :zap: Streaming torrent client for the web.
 
 ![webtorrent](https://camo.githubusercontent.com/357343e823b1c8d37418edce5ac401832eda2d27/68747470733a2f2f776562746f7272656e742e696f2f696d672f576562546f7272656e742e706e67)
 
 WebTorrent is a streaming torrent client for node.js and the browser.
-
 
 ## Y
 

--- a/languages/JAVASCRIPT.md
+++ b/languages/JAVASCRIPT.md
@@ -1,12 +1,12 @@
 ## Alphabetical index of projects in Javascript:
 
-|         |         |         |         |         |         |         |
-| ------- | ------- | ------- | ------- | ------- | ------- | ------- |
-| [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) |
-| [H](#h) | [I](#i) | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) |
-| [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s) | [T](#t) | [U](#u) |
-| [V](#v) | [W](#w) | [X](#x) | [Y](#y) | [Z](#z) |         |         |
-|         |         |         |         |         |         |         |
+|       |       |       |       |       |       |       |
+|---    |---    |---    |---    |---    |---    |    ---|
+|[A](#a)|[B](#b)|[C](#c)|[D](#d)|[E](#e)|[F](#f)|[G](#g)|
+|[H](#h)|[I](#i)|[J](#j)|[K](#k)|[L](#l)|[M](#m)|[N](#n)|
+|[O](#o)|[P](#p)|[Q](#q)|[R](#r)|[S](#s)|[T](#t)|[U](#u)|
+|[V](#v)|[W](#w)|[X](#x)|[Y](#y)|[Z](#z)|       |       |
+|       |       |       |       |       |       |       |
 
 <br>
 
@@ -17,7 +17,6 @@
 ![aframe](https://cloud.githubusercontent.com/assets/674727/21375108/2c10b308-c6e0-11e6-945e-2394beb9a8ed.png)
 
 ---
-
 [**Ace**](https://github.com/ajaxorg/ace)  —  Ace is a standalone code editor written in JavaScript.
 
 Ace's goal is to create a browser based editor that matches and extends the features, usability and performance of existing native editors such as TextMate, Vim or Eclipse. It can be easily embedded in any web page or JavaScript application. Ace is developed as the primary editor for Cloud9 IDE and the successor of the Mozilla Skywriter (Bespin) Project.
@@ -31,7 +30,6 @@ Ace's goal is to create a browser based editor that matches and extends the feat
 ![async](https://cdn-images-1.medium.com/max/720/0*MB_a8lRqGYBy276_.jpg)
 
 ---
-
 [**AVA**](https://github.com/avajs/ava) is Futuristic JavaScript test runner. Ava takes advantage of JavaScript asynchronism to runs your tests concurrently, which is especially beneficial for IO heavy tests. AVA has simple test syntax and enforces atomic tests.
 
 ![](http://i.imgur.com/sUreNq4.gif)
@@ -57,10 +55,10 @@ Chart.js provides two different builds that are available for your use. The Char
 ![chart.js](https://cdn-images-1.medium.com/max/720/0*bFZZQzdNeZkoy3Ov.jpg)
 
 ---
-
-[**Countly**](https://github.com/countly/countly-server)  — A plugin-based, real-time mobile, web and desktop analytics platform with more than 10 different SDKs. Countly also includes an extensive push notifications and crash reporting service for mobile devices.
+[**Countly**](https://github.com/countly/countly-server)  —  A plugin-based, real-time mobile, web and desktop analytics platform with more than 10 different SDKs. Countly also includes an extensive push notifications and crash reporting service for mobile devices.
 
 ![countly](https://count.ly/images/home/countly-overview.png?v2)
+
 
 ## D
 
@@ -69,19 +67,17 @@ Chart.js provides two different builds that are available for your use. The Char
 ![d3](https://cdn-images-1.medium.com/max/720/0*bxHj6VbZ9lApwWyo.jpg)
 
 ---
-
 [**date-fns**](https://github.com/date-fns/date-fns) — :hourglass: Modern JavaScript date utility library :hourglass:.
 
 date-fns provides the most comprehensive, yet simple and consistent toolset for manipulating JavaScript dates in a **Browser** & **Node.js**.
 
----
 
+---
 [**Docsify**](https://github.com/QingWei-Li/docsify)  —  :black_joker: A magical documentation site generator.
 
 ![docsify](https://docsify.js.org/_media/icon.svg)
 
 ## E
-
 [**Enzyme**](https://github.com/airbnb/enzyme) is a JavaScript Testing utility for React that makes it easier to assert, manipulate, and traverse your React Components’ output.
 
 Enzyme’s API is meant to be intuitive and flexible by mimicking jQuery’s API for DOM manipulation and traversal.
@@ -89,13 +85,11 @@ Enzyme’s API is meant to be intuitive and flexible by mimicking jQuery’s API
 Enzyme is unopinionated regarding which test runner or assertion library you use, and should be compatible with all major test runners and assertion libraries out there. The documentation and examples for enzyme use mocha and chai, but you should be able to extrapolate to your framework of choice.
 
 ---
-
-[**Express**](https://github.com/expressjs/express)  — Fast, unopinionated, minimalist web framework for node.
+[**Express**](https://github.com/expressjs/express)  — Fast, unopinionated, minimalist web framework for node.  
 
 ![express](http://imgur.com/mSHVwME.png)
 
 ---
-
 [**Exifr**](https://github.com/MikeKovarik/exifr) — The fastest and most versatile JS EXIF reading library.
 
 ![exifr](https://raw.githubusercontent.com/MikeKovarik/exifr/master/logo/blue-mini.png)
@@ -107,19 +101,16 @@ Enzyme is unopinionated regarding which test runner or assertion library you use
 ![fabric](https://raw.githubusercontent.com/kangax/fabric.js/master/lib/screenshot.png)
 
 ---
-
 [**filepond**](https://github.com/pqina/filepond) — is library that can upload anything you throw at it, optimizes images for faster uploads, and offers a great, accessible, silky smooth user experience.
 
 ![filepond](https://github.com/pqina/filepond-github-assets/blob/master/logo.svg)
 
 ---
-
 [**fullPage.js**](https://github.com/alvarotrigo/fullPage.js) — a simple and easy to use plugin to create fullscreen scrolling websites (also known as single page websites or onepage sites). It allows the creation of fullscreen scrolling websites, as well as adding some landscape sliders inside the sections of the site.
 
 ![fullpage](https://camo.githubusercontent.com/0a9ce533243ea122eb9fba3f93efb5426cc8b6e1/68747470733a2f2f7261772e6769746875622e636f6d2f616c7661726f747269676f2f66756c6c506167652e6a732f6d61737465722f6578616d706c65732f696d67732f696e74726f2e706e67)
 
 ## G
-
 [**Gatsby**](https://github.com/gatsbyjs/gatsby) — ⚛️📄🚀 Blazing-fast site generator for React
 
 Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and super extensive.
@@ -127,13 +118,11 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![gatsby](https://camo.githubusercontent.com/ac31ac54c2013850b0fb8a3a4926f4718a398fb3/68747470733a2f2f7777772e6761747362796a732e6f72672f6d6f6e6f6772616d2e737667)
 
 ---
-
 [**Ghost**](https://github.com/TryGhost/Ghost)  — A simple, powerful publishing platform.
 
 ![ghost](http://imgur.com/gLARrBe.png)
 
 ---
-
 [**Gulp**](https://github.com/gulpjs/gulp)  — The streaming build system.
 
 ![gulp](http://imgur.com/92epDTJ.png)
@@ -145,7 +134,6 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 ![hexo](http://imgur.com/EpeRsnm.png)
 
 ---
-
 [**Hyper**](https://github.com/zeit/hyper)  —  A terminal built on web technologies.
 
 ![hyper](https://raw.githubusercontent.com/zeit/art/525bd1bb39d97dd3b91c976106a6d5cc5766b678/hyper/repo-banner.png)
@@ -153,7 +141,6 @@ Gatsby is a blazing-fast static site generator for React. Powered By GraphQL and
 It is written in HTML, CSS & JavaScript.
 
 ---
-
 [**Highcharts**](https://github.com/highcharts/highcharts)  —  A charting library written in pure JavaScript, offering an easy way of adding interactive charts to your web site or web application..
 
 ![hyper](https://github.com/Pratyush2710/VassarAngularJS/blob/master/highchatrs.png?raw=true)
@@ -161,7 +148,6 @@ It is written in HTML, CSS & JavaScript.
 It is based on HTML5/SVG/VML, meaning it requires no extra plugins and it also supports a wide range of charts like spline, column, bar, maps, angular gauges among others along with being free for personal use.
 
 ---
-
 [**Hapi**](https://github.com/hapijs/hapi) is a rich framework for building applications and services. It enables developers to focus on writing reusable application logic instead of spending time building infrastructure.
 It is a configuration-driven pattern, traditionally modeled to control web server operations. A unique feature Hapi has is the ability to create a server on a specific IP, with features like the onPreHandler, we can do something with a request before it is completed by intercepting it and doing some pre-processing on the request.
 
@@ -174,13 +160,11 @@ Impress.js is inspired by the idea behind [Prezi](https://prezi.com/).
 [Check out the live demo](http://impress.github.io/impress.js).
 
 ---
-
 [**Ink**](https://github.com/vadimdemedes/ink) provides the same component-based UI building experience that React provides, but for command-line apps.
 
 ![ink](https://github.com/vadimdemedes/ink/blob/master/media/demo.svg)
 
 ---
-
 [**Insomnia**](https://github.com/Kong/insomnia) is a desktop cross-platform API client for REST and GraphQL, built on top of Electron. It takes the pain out of interacting with HTTP-based APIs. Insomnia combines an easy-to-use interface with advanced functionality like authentication helpers, code generation, and environment variables. It's an open source alternative to Postman which offers a simpler and cleaner user interface.
 
 The project's site: https://insomnia.rest/
@@ -200,13 +184,11 @@ The project's site: https://insomnia.rest/
 ![](https://camo.githubusercontent.com/de0532955fea66f17b749ef96c7efdbfad2e8bd2/687474703a2f2f692e696d6775722e636f6d2f547665617065372e706e67)
 
 ---
-
 [**Leaflet**](https://github.com/Leaflet/Leaflet) — The leading open-source JavaScript library for mobile-friendly interactive maps.
 
 ![leaflet](https://camo.githubusercontent.com/1a8472d37458cb6e12c17497d95f7752b7e63d0b60f95c507863efca493a04d3/68747470733a2f2f7261776769742e636f6d2f4c6561666c65742f4c6561666c65742f6d61737465722f7372632f696d616765732f6c6f676f2e737667)
 
 ---
-
 [**lodash**](https://github.com/lodash/lodash) — A modern JavaScript utility library delivering modularity, performance, & extras.
 
 ![lodash](http://imgur.com/dIzDcos.png)
@@ -220,19 +202,16 @@ Mailspring's UI is open source (GPLv3) and written in JavaScript with Electron a
 ![Mailspring Screenshot](https://github.com/Foundry376/Mailspring/raw/master/screenshots/hero_graphic_mac%402x.png)
 
 ---
-
 [**Marko**](https://github.com/marko-js/marko) is a friendly and super fast UI library that makes building web apps fun!
 
 ![marko](https://user-images.githubusercontent.com/3771924/29725582-a043b5fe-899a-11e7-83f8-215fdc904256.png)
 
 ---
-
 [**Moment.js**](https://github.com/moment/moment) — a lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 
 ![moment.js](https://cdn-images-1.medium.com/max/720/0*DP6jZMrfJIt2znNM.png)
 
 ---
-
 [**Meteor**](https://github.com/meteor/meteor) is an ultra-simple environment for building modern web applications.
 
 With Meteor you write apps in modern JavaScript that send data over the wire, rather than HTML using your choice of popular open-source libraries
@@ -240,7 +219,6 @@ With Meteor you write apps in modern JavaScript that send data over the wire, ra
 ![meteor](https://user-images.githubusercontent.com/841294/26841702-0902bbee-4af3-11e7-9805-0618da66a246.png)
 
 ## N
-
 [**NSFW**](https://github.com/infinitered/nsfwjs) — Client-side indecent content checking
 
 A simple JavaScript library to help you quickly identify unseemly images; all in the client's browser. NSFWJS isn't perfect, but it's pretty accurate (~90% from our test set of 15,000 test images)... and it's getting more accurate all the time.
@@ -248,13 +226,11 @@ A simple JavaScript library to help you quickly identify unseemly images; all in
 ![nsfwjs](https://github.com/infinitered/nsfwjs/raw/master/_art/nsfwjs_logo.jpg)
 
 ---
-
 [**NestJS**](https://github.com/nestjs/nest) is a framework for building efficient, scalable Node.js server-side applications. It uses modern JavaScript, is built with TypeScript (preserves compatibility with pure JavaScript) and combines elements of OOP (Object Oriented Programming), FP (Functional Programming), and FRP (Functional Reactive Programming).
 
 Under the hood, Nest makes use of Express, but also, provides compatibility with a wide range of other libraries, like e.g. Fastify, allowing for easy use of the myriad third-party plugins which are available.
 
 ---
-
 [**Next.js**](https://github.com/vercel/next.js/) is an open-source web development framework created by Vercel enabling React-based web applications with server-side rendering and generating static websites
 
 Next.js gives you the best developer experience with all the features you need for production: hybrid static & server rendering, TypeScript support, smart bundling, route pre-fetching, and more. No config needed.
@@ -262,7 +238,6 @@ Next.js gives you the best developer experience with all the features you need f
 ![next.js](https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png)
 
 ## P
-
 [**Phaser**](https://github.com/photonstorm/phaser)
 Phaser is a fast, free, and fun open source HTML5 game framework that offers WebGL and Canvas rendering across desktop and mobile web browsers. Games can be compiled to iOS, Android and native apps by using 3rd party tools. You can use JavaScript or TypeScript for development.
 
@@ -273,18 +248,18 @@ Thousands of developers from indie and multi-national digital agencies, and univ
 ![Phaser Header](https://phaser.io/images/github/300/phaser-header.png "Phaser 3 Header Banner")
 
 ---
-
 [**PM2**](http://github.com/Unitech/pm2) is a production process manager for Node.js applications with a built-in load balancer. It allows you to keep applications alive forever, to reload them without downtime and to facilitate common system admin tasks.
 
 ![Process listing](https://github.com/unitech/pm2/raw/master/pres/pm2-list.png)
 
 ---
-
 [**Popper.js**](https://popper.js.org/) This JavaScript library will help you create delightful poppers on your site. If you’re wondering what a popper is, think of it like a little thought bubble bursting from an element! Popper.js gives you some fantastic ways to arrange them, make them stick to elements, and keep them operating smoothly on any screen size
 
 ![Popper.js](https://popper.js.org/images/popper-og-image.jpg)
 
 ---
+
+
 
 [**PouchDB**](https://github.com/pouchdb/pouchdb) is an open-source JavaScript database inspired by Apache CouchDB that is designed to run well within the browser.
 
@@ -292,53 +267,52 @@ PouchDB was created to help web developers build applications that work as well 
 It enables applications to store data locally while offline, then synchronize it with CouchDB and compatible servers when the application is back online, keeping the user's data in sync no matter where they next login.
 
 Usage:
-
 ```javascript
-var db = new PouchDB("dbname");
+var db = new PouchDB('dbname');
 
 db.put({
-  _id: "dave@gmail.com",
-  name: "David",
-  age: 69,
+  _id: 'dave@gmail.com',
+  name: 'David',
+  age: 69
 });
 
-db.changes().on("change", function () {
-  console.log("Ch-Ch-Changes");
+db.changes().on('change', function() {
+  console.log('Ch-Ch-Changes');
 });
 
-db.replicate.to("http://example.com/mydb");
+db.replicate.to('http://example.com/mydb');
 ```
 
 ## R
-
 [**React**](https://github.com/facebook/react) — React is a JavaScript library for building user interfaces.
 ![React](https://www.seekpng.com/png/detail/80-803597_io-is-compatible-with-all-javascript-frameworks-and.png)
 
-- **Declarative:** React makes it painless to create interactive UIs. Design simple views for each state in your application, and React will efficiently update and render just the right components when your data changes. Declarative views make your code more predictable, simpler to understand, and easier to debug.
-- **Component-Based:** Build encapsulated components that manage their own state, then compose them to make complex UIs. Since component logic is written in JavaScript instead of templates, you can easily pass rich data through your app and keep state out of the DOM.
-- **Learn Once, Write Anywhere:** We don't make assumptions about the rest of your technology stack, so you can develop new features in React without rewriting existing code. React can also render on the server using Node and power mobile apps using [React Native](https://facebook.github.io/react-native/).
+
+* **Declarative:** React makes it painless to create interactive UIs. Design simple views for each state in your application, and React will efficiently update and render just the right components when your data changes. Declarative views make your code more predictable, simpler to understand, and easier to debug.
+* **Component-Based:** Build encapsulated components that manage their own state, then compose them to make complex UIs. Since component logic is written in JavaScript instead of templates, you can easily pass rich data through your app and keep state out of the DOM.
+* **Learn Once, Write Anywhere:** We don't make assumptions about the rest of your technology stack, so you can develop new features in React without rewriting existing code. React can also render on the server using Node and power mobile apps using [React Native](https://facebook.github.io/react-native/).
 
 [Learn how to use React in your own project](https://react.dev/learn).
 
 ---
-
 [**Redux**](https://github.com/facebook/react) — Redux is a predictable state container for JavaScript apps.
 
 ![React](https://redux.js.org/img/redux-logo-landscape.png)
 
-- **Predictability of outcome** There is always one source of truth, the store, with no confusion about how to sync the current state with actions and other parts of the application.
 
-- **Maintainability** Having a predictable outcome and strict structure makes the code easier to maintain.
+* **Predictability of outcome**  There is always one source of truth, the store, with no confusion about how to sync the current state with actions and other parts of the application.
 
-- **Server rendering** This is very useful, especially for the initial render, making for a better user experience or search engine optimization. Just pass the store created on the server to the client side.
+* **Maintainability** Having a predictable outcome and strict structure makes the code easier to maintain.
 
-- **Organization** Redux is stricter about how code should be organized, which makes code more consistent and easier for a team to work with.
+* **Server rendering** This is very useful, especially for the initial render, making for a better user experience or search engine optimization. Just pass the store created on the server to the client side.
 
-- **Developer tools** Developers can track everything going on in the app in real time, from actions to state changes.
+* **Organization** Redux is stricter about how code should be organized, which makes code more consistent and easier for a team to work with.
 
-- **Community and ecosystem** This is a huge plus whenever you’re learning or using any library or framework. Having a community behind Redux makes it even more appealing to use.
+* **Developer tools** Developers can track everything going on in the app in real time, from actions to state changes.
 
-- **Ease of testing** The first rule of writing testable code is to write small functions that do only one thing and that are independent. Redux’s code is mostly functions that are just that: small, pure and isolated.
+* **Community and ecosystem** This is a huge plus whenever you’re learning or using any library or framework. Having a community behind Redux makes it even more appealing to use.
+
+* **Ease of testing** The first rule of writing testable code is to write small functions that do only one thing and that are independent. Redux’s code is mostly functions that are just that: small, pure and isolated.
 
 ---
 
@@ -352,10 +326,11 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 
 [**Routing Controllers**](https://github.com/typestack/routing-controllers) — A framework for building backend applications in Node.
 
-- It is quite lightweight, easy to learn and pleasant to use.
-- It allows to create structured, declarative and beautifully organized class-based controllers.
-- It has heavy decorators usage providing with efficient logging, functionality, and test performance.
-- It can be used easily in Express / Koa using TypeScript.
+* It is quite lightweight, easy to learn and pleasant to use.
+* It allows to create structured, declarative and beautifully organized class-based controllers.
+* It has heavy decorators usage providing with efficient logging, functionality, and test performance.
+* It can be used easily in Express / Koa using TypeScript.
+
 
 ## S
 
@@ -364,25 +339,22 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ![socket.io](http://imgur.com/2p9ICjI.png)
 
 ---
-
 [**Strapi**](https://github.com/strapi/strapi) — The most advanced open-source Content Management Framework (headless-CMS) to build powerful API with no effort.
 
 ![strapi](https://camo.githubusercontent.com/4f99be4e64e0babc77b1e0dadffd3eb5ba883ebb/68747470733a2f2f626c6f672e7374726170692e696f2f636f6e74656e742f696d616765732f323031382f30382f6769746875625f707265766965772d322e706e67)
 
 ---
-
 [**strider**](https://github.com/Strider-CD/strider) — an Open Source Continuous Deployment / Continuous Integration platform. It is written in Node.JS / JavaScript and uses MongoDB as a backing store. It is published under the BSD license.
 
 ![strider](https://cdn-images-1.medium.com/max/720/0*xth8wmt1O-zAf3Hy.jpg)
 
 ---
-
 [**Svelte**](https://github.com/sveltejs/svelte) — Svelte is a UI framework of sorts that borrows a lot of the great ideas from some of its peers like React and Vue.js, but brings about its own interesting ideas to the table. Plus, it’s not entirely a framework in the sense that we’re used to and is perhaps better seen as a compiler.
+
 
 ![svelte](https://svelte.dev/svelte-logo-horizontal.svg)
 
 ---
-
 [**SweetAlert2**](https://github.com/limonte/sweetalert2) — An awesome replacement for JavaScript's alert.
 
 [Check out the live demo](https://github.com/limonte/sweetalert2).
@@ -390,7 +362,6 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ![sweetalert](https://raw.githubusercontent.com/sweetalert2/sweetalert2/master/assets/swal2-logo.png)
 
 ---
-
 [**Serverless Framework**](https://github.com/serverless/serverless) — Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more!
 
 The Framework uses new event-driven compute services, like AWS Lambda, Google Cloud Functions, and more. It's a command-line tool, providing scaffolding, workflow automation and best practices for developing and deploying your serverless architecture. It's also completely extensible via plugins.
@@ -404,13 +375,11 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 ![](https://raw.githubusercontent.com/DevExpress/testcafe/master/media/install-and-run-test.gif)
 
 ---
-
 [**Three.js**](https://github.com/mrdoob/three.js) is a cross-browser JavaScript library/API used to create and display animated 3D computer graphics in a web browser. Three.js uses WebGL.
 
 ![three](http://www.awwwards.com/awards/images/2014/09/threejs-img8.jpg)
 
 ---
-
 [**Tone.js**](https://github.com/Tonejs/Tone.js) is a framework for creating interactive music in the browser. It provides advanced scheduling capabilities, synths and effects, and intuitive musical abstractions built on top of the Web Audio API.
 
 [Check out the live demos.](https://tonejs.github.io/demos)
@@ -435,7 +404,7 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 
 ---
 
-[**VuePress**](https://github.com/vuejs/vuepress) — VuePress is a Minimalistic Vue-powered static site generator with Vue component based layout and is the latest project from Vue creator Evan You. On the client side, a VuePress site is an SPA powered by Vue, Vue Router and Webpack. It was originally created to support the documentation needs of Vue’s own subprojects and now it can serve your own needs. A VuePress site is in fact a SPA powered by Vue, Vue Router and webpack. If you’ve used Vue before, you will notice the familiar development experience when you are writing or developing custom themes.
+[**VuePress**](https://github.com/vuejs/vuepress) — VuePress is a Minimalistic Vue-powered static site generator with Vue component based layout and is the latest project from Vue creator Evan You. On the client side, a VuePress site is an SPA powered by Vue, Vue Router and Webpack. It was originally created to support the documentation needs of Vue’s own subprojects and now it can serve your own needs. A VuePress site is in fact a SPA powered by Vue, Vue Router and webpack. If you’ve used Vue before, you will notice the familiar development experience when you are writing or developing custom themes. 
 
 [Learn how to use VuePress - official guide](https://vuepress.vuejs.org/guide).
 
@@ -448,18 +417,17 @@ The Framework uses new event-driven compute services, like AWS Lambda, Google Cl
 ![webpack](http://imgur.com/i5lsaAm.png)
 
 ---
-
 [**web3.js - Ethereum JavaScript API**](https://github.com/ethereum/web3.js/) — web3.js is a collection of libraries which allow you to interact with a local or remote ethereum node, using a HTTP or IPC connection.
 
 ![web3.js](https://raw.githubusercontent.com/ethereum/web3.js/2.x/assets/web3js.svg?sanitize=true)
 
 ---
-
 [**WebTorrent**](https://github.com/feross/webtorrent) — :zap: Streaming torrent client for the web.
 
 ![webtorrent](https://camo.githubusercontent.com/357343e823b1c8d37418edce5ac401832eda2d27/68747470733a2f2f776562746f7272656e742e696f2f696d672f576562546f7272656e742e706e67)
 
 WebTorrent is a streaming torrent client for node.js and the browser.
+
 
 ## Y
 


### PR DESCRIPTION
The old link point to old docs that won’t be updated.
![image](https://user-images.githubusercontent.com/18583152/230713471-05863be9-48d7-4f6c-889c-25a961237431.png)

The new link points to the most recent docs.