### PR TITLE
Add Marten framework

### DIFF
--- a/languages/CRYSTAL.md
+++ b/languages/CRYSTAL.md
@@ -10,3 +10,6 @@
 
 [**Lucky**](https://github.com/luckyframework/lucky) - a web framework that helps you work quickly, catch bugs at compile time, and deliver blazing fast responses.
 
+## M
+
+[**Marten**](https://github.com/martenframework/marten) - A web framework that makes building web applications easy, productive, and fun.


### PR DESCRIPTION
This pull request adds [Marten](https://github.com/martenframework/marten) - a web framework - to the list of projects featured for the Crystal programming language.