### PR TITLE
Put SDL in C

### DIFF
--- a/languages/C++.md
+++ b/languages/C++.md
@@ -119,9 +119,7 @@ actor Main
 
 [**Robomongo**](https://github.com/paralect/robomongo) is a shell-centric cross-platform MongoDB management tool. Unlike most other MongoDB admin UI tools, Robomongo embeds the actual mongo shell in a tabbed interface with access to a shell command line as well as GUI interaction.
 
-## S
 
-[**SDL**](https://www.libsdl.org/) (Simple DirectMedia Layer) is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D. It is used by video playback software, emulators, and popular games including Valve's award winning catalog and many Humble Bundle games. Officially supports Windows, Mac OS X, Linux, iOS, and Android. Support for other platforms may be found in the source code. SDL 2.0 is distributed under the zlib license. This license allows you to use SDL freely in any software.
 
 ## T
 

--- a/languages/C.md
+++ b/languages/C.md
@@ -82,4 +82,8 @@ It derives from the old Numeric code base and can be used as a replacement for N
 
 ## S
 
+[**SDL**](https://www.libsdl.org/) (Simple DirectMedia Layer) is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D. It is used by video playback software, emulators, and popular games including Valve's award winning catalog and many Humble Bundle games. Officially supports Windows, Mac OS X, Linux, iOS, and Android. Support for other platforms may be found in the source code. SDL 2.0 is distributed under the zlib license. This license allows you to use SDL freely in any software.
+
+<br>
+
 [**Skynet**](https://github.com/cloudwu/skynet) is a lightweight online game framework, and it can be used in many other fields.


### PR DESCRIPTION
SDL in written in C, so it doesn't make sense (at least to me) that SDL in `C++.md`.

This PR removes the entry for SDL from `C++.md` and puts it in `C.md`