### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ Just share this list with your friends on [Twitter](https://twitter.com/), [Face
 To the extent possible under law, the person who associated CC0 with `awesomo` has waived all copyright and related or neighboring rights to `awesomo`.
 
 You should have received a copy of the CC0 legalcode along with this work. If not, see https://creativecommons.org/publicdomain/zero/1.0/.
+
+
+## Miscellaneous
+
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.