### PR TITLE
Add MoonProxy — GUI desktop client for FRP (Rust + Tauri v2)

### DIFF
--- a/languages/RUST.md
+++ b/languages/RUST.md
@@ -180,6 +180,12 @@ fn main() {
 
 ## M
 
+[**MoonProxy**](https://github.com/MoonProxyHQ/moonproxy-desktop) is a cross-platform GUI desktop client for FRP (Fast Reverse Proxy), built with Tauri v2 + Rust + Vue 3.
+
+MIT-licensed desktop application that exposes local services to the public internet with one click. Supports macOS (Apple Silicon + Intel) and Windows x64. Bundles frpc binary via Tauri sidecar mechanism — no separate frp installation needed.
+
+<br>
+
 [**Mio**](https://github.com/carllerche/mio) is a lightweight I/O library for Rust with a focus on adding as little overhead as possible over the OS abstractions.
 
 ## N


### PR DESCRIPTION
## MoonProxy

A cross-platform GUI desktop client for [FRP (Fast Reverse Proxy)](https://github.com/fatedier/frp), built with **Tauri v2 + Rust + Vue 3**. Exposes local services to the public internet with one click — no command line, no config files.

**Why it's interesting:**
- FRP is a 107k-star reverse proxy tool, but has always been CLI-only
- MoonProxy is the first Tauri v2 (native Rust backend) GUI client for it
- MIT licensed, bundles frpc via sidecar — zero additional setup
- macOS (Apple Silicon + Intel) + Windows x64

Added under **## M** in , following the existing format.

**Links:**
- GitHub: https://github.com/MoonProxyHQ/moonproxy-desktop
- Homepage: https://moonproxy.app